### PR TITLE
deps: Upgrade minitest to v5.21.1 (latest)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.15.0)
+    minitest (5.21.1)
     net-imap (0.3.4)
       date
       net-protocol

--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -9,3 +9,5 @@ gem 'psych', '< 4' # for safe_load degration
 gem 'bcrypt'
 
 gem 'rbs_rails', path: '../../'
+
+gem 'mutex_m'  # to run Rails6.1 under Ruby 3.4

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     mini_portile2 (2.8.2)
     minitest (5.17.0)
     msgpack (1.4.2)
+    mutex_m (0.2.0)
     nio4r (2.5.8)
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
@@ -154,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   bootsnap
+  mutex_m
   psych (< 4)
   puma
   rails (>= 6, < 7)


### PR DESCRIPTION
Old minitest depends on mutex_m gem (before v5.21) without explicit dependency.  So it causes dependency errors on CI because the mutex_m gem became the bundled gem since Ruby 3.4.

This upgrade minitest to the latest version which does not depends on the mutex_m gem.